### PR TITLE
Refactor: Decompose main.c into separate modules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,7 @@ Makefile.*  linguist-language=Makefile
 AUTHORS     text
 CONTRIBUTE  text
 COPYING     text
+ChangeLog   text
 INSTALL     text
 NEWS        text
 README      text

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,32 @@
+2024-12-10  Serghei Iakovlev  <gnu@serghei>
+
+    * src/utils.c, src/utils.h (new): Utility functions moved here.
+    * src/brogw_config.c, src/brogw_config.h (new): Configuration loading.
+    * src/matcher.c, src/matcher.h (new): Pattern matching with regex.
+    * src/executor.c, src/executor.h (new): Command execution.
+    * src/main.c: Removed inline code for config loading, URL matching,
+      and command execution. Now delegates to the above modules.
+
+    Reorganize code into separate modules for better maintainability
+    and clarity.
+
+;; Local Variables:
+;; coding: utf-8
+;; End:
+
+  Copyright (C) 2024 Free Software Foundation, Inc.
+
+  This file is part of Brogw.
+
+  Brogw is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Brogw is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Brogw.  If not, see <https://www.gnu.org/licenses/>.

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ EXTRA_DIST = \
 	AUTHORS \
 	CONTRIBUTE \
 	COPYING \
+	ChangeLog \
 	INSTALL \
 	NEWS \
 	README \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,4 +16,4 @@
 # along with Brogw.  If not, see <https://www.gnu.org/licenses/>.
 
 bin_PROGRAMS = brogw
-brogw_SOURCES = main.c
+brogw_SOURCES = main.c utils.c brogw_config.c matcher.c executor.c

--- a/src/brogw_config.c
+++ b/src/brogw_config.c
@@ -1,0 +1,133 @@
+/* brogw_config.c
+   Copyright (C) 2024 Free Software Foundation, Inc.
+
+This file is part of Brogw.
+
+Brogw is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Brogw is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Brigw.  If not, see <https://www.gnu.org/licenses/>.  */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "utils.h"
+#include "brogw_config.h"
+
+static int read_config_file(const char *config_path, Rule **rules, size_t *cnt);
+static void resolve_config_path(char *config_path, size_t len);
+
+int config_load_rules(Rule **rules, size_t *cnt) {
+  char config_path[CONFIG_PATH_LENGTH];
+  resolve_config_path(config_path, sizeof(config_path));
+
+  Rule *rules_int = NULL;
+  size_t count = 0;
+
+  if (read_config_file(config_path, &rules_int, &count) != 0) {
+    return -1;
+  }
+
+  *rules = rules_int;
+  *cnt = count;
+  return 0;
+}
+
+void config_free_rules(Rule *rules, size_t cnt) {
+  if (!rules) return;
+
+  for (size_t i = 0; i < cnt; i++) {
+    free(rules[i].pattern);
+    free(rules[i].command);
+  }
+
+  free(rules);
+}
+
+static void resolve_config_path(char *config_path, size_t len) {
+  const char *cwd = getenv("PWD");
+  if (cwd) {
+    snprintf(config_path, len, "%s/config.conf", cwd);
+    if (access(config_path, R_OK) == 0) return;
+  }
+
+  const char *xdg_config = getenv("XDG_CONFIG_HOME");
+  if (xdg_config) {
+    snprintf(config_path, len, "%s/brogw/config.conf", xdg_config);
+    if (access(config_path, R_OK) == 0) return;
+  } else {
+    const char *home = getenv("HOME");
+    if (home) {
+      snprintf(config_path, len, "%s/.config/brogw/config.conf", home);
+      if (access(config_path, R_OK) == 0) return;
+    }
+  }
+
+  snprintf(config_path, len, "/etc/brogw/config.conf");
+}
+
+static int read_config_file(const char *path, Rule **rules, size_t *cnt) {
+  FILE *f = fopen(path, "r");
+  if (!f) return -1;
+
+  char line[512];
+  size_t capacity = 10;
+  Rule *list = malloc(sizeof(Rule)*capacity);
+  if (!list) {
+    fclose(f);
+    return -1;
+  }
+
+  size_t count = 0;
+  while (fgets(line, sizeof(line), f)) {
+    if (line[0] == '#' || strlen(line) < 3) {
+      continue; /* Skip comments and empty lines */
+    }
+
+    char *sep = strchr(line, '=');
+    if (!sep) continue;
+
+    *sep = '\0';
+    char *pattern = line;
+    char *command = sep+1;
+
+    trim(pattern);
+    trim(command);
+
+    if (strlen(pattern) == 0 || strlen(command) == 0)
+      continue;
+
+    if (count == capacity) {
+      capacity *= 2;
+      Rule *new_list = realloc(list, sizeof(Rule)*capacity);
+      if (!new_list) {
+        free(list);
+        fclose(f);
+        return -1;
+      }
+      list = new_list;
+    }
+
+    list[count].pattern = strdup(pattern);
+    list[count].command = strdup(command);
+    count++;
+  }
+
+  fclose(f);
+
+  *rules = list;
+  *cnt = count;
+  return 0;
+}

--- a/src/brogw_config.h
+++ b/src/brogw_config.h
@@ -1,0 +1,42 @@
+/* brogw_config.h
+   Copyright (C) 2024 Free Software Foundation, Inc.
+
+This file is part of Brogw.
+
+Brogw is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Brogw is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Brigw.  If not, see <https://www.gnu.org/licenses/>.  */
+
+
+#ifndef BROGW_BROGW_CONFIG_H
+#define BROGW_BROGW_CONFIG_H
+
+#include <stddef.h>
+
+#define MAX_COMMAND_LENGTH 256
+#define CONFIG_PATH_LENGTH 256
+
+typedef struct {
+  char *pattern;
+  char *command;
+} Rule;
+
+/* Load configuration rules from files based on priority.
+   Returns 0 on success, non-zero on failure.
+   Allocates memory for rules and stores the pointer in *rules.
+   Caller is responsible for calling config_free_rules(). */
+int config_load_rules(Rule **out, size_t *cnt);
+
+/* Free memory allocated for rules. */
+void config_free_rules(Rule *rules, size_t cnt);
+
+#endif

--- a/src/executor.c
+++ b/src/executor.c
@@ -1,0 +1,36 @@
+/* executor.c
+   Copyright (C) 2024 Free Software Foundation, Inc.
+
+This file is part of Brogw.
+
+Brogw is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Brogw is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Brigw.  If not, see <https://www.gnu.org/licenses/>.  */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "executor.h"
+
+int executor_run_command(const char *command, const char *url) {
+    char full_command[512];
+    snprintf(full_command, sizeof(full_command), "%s '%s'", command, url);
+
+    int ret = system(full_command);
+    if (ret == -1) {
+        return 1;
+    }
+    return 0;
+}

--- a/src/executor.h
+++ b/src/executor.h
@@ -1,0 +1,27 @@
+/* executor.h
+   Copyright (C) 2024 Free Software Foundation, Inc.
+
+This file is part of Brogw.
+
+Brogw is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Brogw is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Brigw.  If not, see <https://www.gnu.org/licenses/>.  */
+
+
+#ifndef BROGW_EXECUTOR_H
+#define BROGW_EXECUTOR_H
+
+/* Execute the given command with the given URL as argument.
+   Return 0 on success, non-zero on failure. */
+int executor_run_command(const char *command, const char *url);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,4 @@
-/* Main entrypoint for Brogw.
+/* main.c - Main entrypoint for Brogw.
    Copyright (C) 2024 Free Software Foundation, Inc.
 
 This file is part of Brogw.
@@ -20,128 +20,12 @@ along with Brigw.  If not, see <https://www.gnu.org/licenses/>.  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <regex.h>
-#include <errno.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdarg.h>
 
-#define MAX_RULES 50
-#define MAX_COMMAND_LENGTH 256
-#define CONFIG_PATH_LENGTH 256
+#include "brogw_config.h"
+#include "utils.h"
+#include "matcher.h"
+#include "executor.h"
 
-// Rule structure
-typedef struct {
-  char pattern[128];
-  char command[MAX_COMMAND_LENGTH];
-} Rule;
-
-Rule rules[MAX_RULES];
-int rule_count = 0;
-
-const char *defaultBrowser = "firefox";
-
-/* Utility to trim whitespace */
-void trim(char *str) {
-  char *end;
-
-  /* Trim leading space */
-  while (isspace((unsigned char)*str)) str++;
-
-  if (*str == 0) {
-    return;
-  }
-
-  /* Trim trailing space */
-  end = str + strlen(str) - 1;
-  while (end > str && isspace((unsigned char)*end)) end--;
-
-  *(end + 1) = '\0';
-}
-
-/* Load configuration from file with debug messages */
-int loadConfig(const char *configPath) {
-  FILE *file = fopen(configPath, "r");
-  if (!file) {
-    return -1;
-  }
-
-  char line[512];
-  while (fgets(line, sizeof(line), file)) {
-    if (line[0] == '#' || strlen(line) < 3) {
-      continue; /* Skip comments and empty lines */
-    }
-
-    char *pattern = strtok(line, "=");
-    char *command = strtok(NULL, "\n");
-
-    if (pattern && command) {
-      trim(pattern);
-      trim(command);
-
-      if (rule_count < MAX_RULES) {
-        snprintf(rules[rule_count].pattern, sizeof(rules[rule_count].pattern), "%s", pattern);
-        snprintf(rules[rule_count].command, sizeof(rules[rule_count].command), "%s", command);
-        rule_count++;
-      }
-    }
-  }
-
-  fclose(file);
-  return rule_count > 0 ? 0 : -1;
-}
-
-/* Find browser command for a URL with debug messages */
-const char *findBrowserCommand(const char *url) {
-  static char command[MAX_COMMAND_LENGTH];
-  regex_t regex;
-  int reti;
-
-  for (int i = 0; i < rule_count; i++) {
-    reti = regcomp(&regex, rules[i].pattern, REG_EXTENDED);
-    if (reti) {
-      fprintf(stderr, "Could not compile regex\n");
-      exit(1);
-    }
-
-    reti = regexec(&regex, url, 0, NULL, 0);
-    regfree(&regex);
-
-    if (!reti) {
-      snprintf(command, MAX_COMMAND_LENGTH, "%s", rules[i].command);
-      return command;
-    }
-  }
-
-  return defaultBrowser;
-}
-
-/* Resolve configuration file */
-void resolveConfigPath(char *configPath) {
-  char *cwd = getenv("PWD");
-  char *xdgConfig = getenv("XDG_CONFIG_HOME");
-
-  if (cwd) {
-    snprintf(configPath, CONFIG_PATH_LENGTH, "%s/config.conf", cwd);
-    if (access(configPath, R_OK) == 0) {
-      return;
-    }
-  }
-
-  if (xdgConfig) {
-    snprintf(configPath, CONFIG_PATH_LENGTH, "%s/brogw/config.conf", xdgConfig);
-    if (access(configPath, R_OK) == 0) {
-      return;
-    }
-  } else {
-    snprintf(configPath, CONFIG_PATH_LENGTH, "%s/.config/brogw/config.conf", getenv("HOME"));
-    if (access(configPath, R_OK) == 0) {
-      return;
-    }
-  }
-
-  snprintf(configPath, CONFIG_PATH_LENGTH, "/etc/brogw/config.conf");
-}
 
 int main(int argc, char *argv[]) {
   if (argc < 2) {
@@ -150,30 +34,31 @@ int main(int argc, char *argv[]) {
   }
 
   const char *url = argv[1];
-
   if (strncmp(url, "http://", 7) != 0 && strncmp(url, "https://", 8) != 0) {
     fprintf(stderr, "Invalid URL. Must start with http:// or https://\n");
     return 1;
   }
 
-  char configPath[CONFIG_PATH_LENGTH];
-  resolveConfigPath(configPath);
-
-  if (loadConfig(configPath) != 0) {
-    fprintf(stderr, "Error loading config\n");
+  Rule *rules = NULL;
+  size_t rule_count = 0;
+  if (config_load_rules(&rules, &rule_count) != 0) {
+    fprintf(stderr, "Error loading configuration\n");
     return 1;
   }
 
-  const char *browserCommand = findBrowserCommand(url);
+  const char *default_browser = "firefox";
+  const char *command = matcher_find_command(url, rules, rule_count, default_browser);
 
-  char fullCommand[MAX_COMMAND_LENGTH + 256];
-  snprintf(fullCommand, sizeof(fullCommand), "%s '%s'", browserCommand, url);
+  // For now, just print how many rules we have loaded
+  printf("Loaded %zu rules.\n", rule_count);
+  printf("Command to execute: %s\n", command);
 
-  int ret = system(fullCommand);
-  if (ret == -1) {
-    perror("Error executing command");
-    return 1;
+  int ret = executor_run_command(command, url);
+  if (ret != 0) {
+    fprintf(stderr, "Failed to execute command: %s\n", command);
   }
 
-  return 0;
+  // In the future, we will integrate matcher and executor here.
+  config_free_rules(rules, rule_count);
+  return ret;
 }

--- a/src/matcher.c
+++ b/src/matcher.c
@@ -1,0 +1,49 @@
+/* matcher.c
+   Copyright (C) 2024 Free Software Foundation, Inc.
+
+This file is part of Brogw.
+
+Brogw is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Brogw is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Brigw.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#include <regex.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "matcher.h"
+
+const char *matcher_find_command(const char *url, const Rule *rules,
+                                 size_t cnt, const char *default_browser) {
+  static char command[MAX_COMMAND_LENGTH];
+  regex_t regex;
+  int reti;
+
+  for (size_t i = 0; i < cnt; i++) {
+    reti = regcomp(&regex, rules[i].pattern, REG_EXTENDED);
+    if (reti != 0) {
+      /* If regex compilation fails, skip this rule */
+      continue;
+    }
+
+    reti = regexec(&regex, url, 0, NULL, 0);
+    regfree(&regex);
+
+    if (!reti) {
+      snprintf(command, sizeof(command), "%s", rules[i].command);
+      return command;
+    }
+  }
+
+  return default_browser;
+}

--- a/src/matcher.h
+++ b/src/matcher.h
@@ -1,0 +1,30 @@
+/* matcher.h
+   Copyright (C) 2024 Free Software Foundation, Inc.
+
+This file is part of Brogw.
+
+Brogw is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Brogw is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Brigw.  If not, see <https://www.gnu.org/licenses/>.  */
+
+
+#ifndef BROGW_MATCHER_H
+#define BROGW_MATCHER_H
+
+#include "brogw_config.h"
+
+/* Find a matching browser command for the given URL using the list of rules.
+   If no rule matches, return default_browser. */
+const char *matcher_find_command(const char *url, const Rule *rules,
+                                 size_t cnt, const char *default_browser);
+
+#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,48 @@
+/* utils.h - Common utility functions.
+   Copyright (C) 2024 Free Software Foundation, Inc.
+
+This file is part of Brogw.
+
+Brogw is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Brogw is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Brigw.  If not, see <https://www.gnu.org/licenses/>.  */
+
+
+#include <ctype.h>
+#include <string.h>
+
+#include "utils.h"
+
+
+/*
+ * Trims leading and trailing whitespace in-place.
+ *
+ * Note: This function modifies the input string buffer directly
+ * and may shift the starting position if leading spaces are removed.
+ * If preserving the original pointer offset is required, consider
+ * copying the trimmed substring back to the original start.
+ */
+void trim(char *str) {
+  char *end;
+
+  /* Trim leading space */
+  while (isspace((unsigned char)*str)) str++;
+
+  if (*str == 0) return;
+
+  /* Trim trailing space */
+  end = str + strlen(str) - 1;
+
+  while (end > str && isspace((unsigned char)*end)) end--;
+
+  *(end + 1) = '\0';
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,26 @@
+/* utils.h - Header file for common utility functions.
+   Copyright (C) 2024 Free Software Foundation, Inc.
+
+This file is part of Brogw.
+
+Brogw is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Brogw is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Brigw.  If not, see <https://www.gnu.org/licenses/>.  */
+
+
+#ifndef BROGW_UTILS_H
+#define BROGW_UTILS_H
+
+/* Utility to trim whitespace */
+void trim(char *str);
+
+#endif


### PR DESCRIPTION
* src/utils.{c,h}: Move generic utility functions (trim).

* src/brogw_config.{c,h}: Introduce a dedicated configuration module for loading rules.

* src/matcher.{c,h}: Add a matcher module for URL-to-command lookup using regex rules.

* src/executor.{c,h}: Add an executor module to run the selected command.

* src/main.c: Now only orchestrates the workflow, delegating details to the above modules.

This change reorganizes the code into distinct modules, improving the overall structure and clarity. It eases maintenance, testing, and future extension without altering user-visible behavior.